### PR TITLE
feat: first try to introduce support for ed25519 jwt token signature

### DIFF
--- a/ast/builtins.go
+++ b/ast/builtins.go
@@ -358,6 +358,8 @@ var JWTVerifyHS384 = v1.JWTVerifyHS384
 
 var JWTVerifyHS512 = v1.JWTVerifyHS512
 
+var JWTVerifyEdDSA = v1.JWTVerifyEdDSA
+
 // Marked non-deterministic because it relies on time internally.
 var JWTDecodeVerify = v1.JWTDecodeVerify
 

--- a/builtin_metadata.json
+++ b/builtin_metadata.json
@@ -207,6 +207,7 @@
     "tokens": [
       "io.jwt.decode",
       "io.jwt.decode_verify",
+      "io.jwt.verify_eddsa",
       "io.jwt.verify_es256",
       "io.jwt.verify_es384",
       "io.jwt.verify_es512",
@@ -371,6 +372,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the number without its sign.",
@@ -505,6 +507,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -644,6 +647,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the intersection of two sets.",
@@ -779,6 +783,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -918,6 +923,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Concatenates two arrays.",
@@ -1004,6 +1010,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the reverse of a given array.",
@@ -1150,6 +1157,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a slice of a given array. If `start` is greater or equal than `stop`, `slice` is `[]`.",
@@ -1287,6 +1295,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": ":=",
@@ -1421,6 +1430,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Deserializes the base64 encoded input string.",
@@ -1557,6 +1567,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input string into base64 encoding.",
@@ -1672,6 +1683,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies the input string is base64 encoded.",
@@ -1808,6 +1820,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Deserializes the base64url encoded input string.",
@@ -1944,6 +1957,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input string into base64url encoding.",
@@ -2057,6 +2071,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input string into base64url encoding without padding.",
@@ -2194,6 +2209,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the bitwise \"AND\" of two integers.",
@@ -2331,6 +2347,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a new integer with its bits shifted `s` bits to the left.",
@@ -2463,6 +2480,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the bitwise negation (flip) of an integer.",
@@ -2600,6 +2618,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the bitwise \"OR\" of two integers.",
@@ -2737,6 +2756,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a new integer with its bits shifted `s` bits to the right.",
@@ -2874,6 +2894,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the bitwise \"XOR\" (exclusive-or) of two integers.",
@@ -3008,6 +3029,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -3140,6 +3162,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -3272,6 +3295,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -3404,6 +3428,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -3536,6 +3561,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -3668,6 +3694,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -3773,6 +3800,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Rounds the number _up_ to the nearest integer.",
@@ -3914,6 +3942,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Joins a set or array of strings with a delimiter.",
@@ -4055,6 +4084,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the search string is included in the base string",
@@ -4191,6 +4221,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": " Count takes a collection or string and returns the number of elements (or characters) in it.",
@@ -4248,6 +4279,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a boolean representing the result of comparing two MACs for equality without leaking timing information.",
@@ -4339,6 +4371,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the MD5 HMAC of the input message using the input key.",
@@ -4430,6 +4463,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA1 HMAC of the input message using the input key.",
@@ -4521,6 +4555,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA256 HMAC of the input message using the input key.",
@@ -4612,6 +4647,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the SHA512 HMAC of the input message using the input key.",
@@ -4748,6 +4784,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the MD5 function",
@@ -4796,6 +4833,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns zero or more private keys from the given encoded string containing DER certificate data.\n\nIf the input is empty, the function will return null. The input string should be a list of one or more concatenated PEM blocks. The whole input of concatenated PEM blocks can optionally be Base64 encoded.",
@@ -4932,6 +4970,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the SHA1 function",
@@ -5068,6 +5107,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string representing the input string hashed with the SHA256 function",
@@ -5163,6 +5203,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns one or more certificates from the given string containing PEM\nor base64 encoded DER certificates after verifying the supplied certificates form a complete\ncertificate chain back to a trusted root.\n\nThe first certificate is treated as the root and the last is treated as the leaf,\nwith all others being treated as intermediates.",
@@ -5206,6 +5247,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns one or more certificates from the given string containing PEM\nor base64 encoded DER certificates after verifying the supplied certificates form a complete\ncertificate chain back to a trusted root. A config option passed as the second argument can\nbe used to configure the validation options used.\n\nThe first certificate is treated as the root and the last is treated as the leaf,\nwith all others being treated as intermediates.",
@@ -5327,6 +5369,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a PKCS #10 certificate signing request from the given PEM-encoded PKCS#10 certificate signing request.",
@@ -5463,6 +5506,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns zero or more certificates from the given encoded string containing\nDER certificate data.\n\nIf the input is empty, the function will return null. The input string should be a list of one or more\nconcatenated PEM blocks. The whole input of concatenated PEM blocks can optionally be Base64 encoded.",
@@ -5519,6 +5563,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a valid key pair",
@@ -5611,6 +5656,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a JWK for signing a JWT from the given PEM-encoded RSA private key.",
@@ -5752,6 +5798,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Divides the first number by the second number.",
@@ -5894,6 +5941,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns true if the search string ends with the base string.",
@@ -6031,6 +6079,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "=",
@@ -6168,6 +6217,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "==",
@@ -6275,6 +6325,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Rounds the number _down_ to the nearest integer.",
@@ -6416,6 +6467,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the string representation of the number in the given base after rounding it down to an integer value.",
@@ -6562,6 +6614,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Parses and matches strings against the glob notation. Not to be confused with `regex.globs_match`.",
@@ -6698,6 +6751,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a string which represents a version of the pattern where all asterisks have been escaped.",
@@ -6830,6 +6884,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Computes the set of reachable nodes in the graph from a set of starting nodes.",
@@ -6919,6 +6974,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Computes the set of reachable paths in the graph from a set of starting nodes.",
@@ -7001,6 +7057,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks that a GraphQL query is valid against a given schema. The query and/or schema can be either GraphQL strings or AST objects from the other GraphQL builtin functions.",
@@ -7083,6 +7140,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns AST objects for a given GraphQL query and schema after validating the query against the schema. Returns undefined if errors were encountered during parsing or validation. The query and/or schema can be either GraphQL strings or AST objects from the other GraphQL builtin functions.",
@@ -7165,6 +7223,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a boolean indicating success or failure alongside the parsed ASTs for a given GraphQL query and schema after validating the query against the schema. The query and/or schema can be either GraphQL strings or AST objects from the other GraphQL builtin functions.",
@@ -7242,6 +7301,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns an AST object for a GraphQL query.",
@@ -7319,6 +7379,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns an AST object for a GraphQL schema.",
@@ -7388,6 +7449,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks that the input is a valid GraphQL schema. The schema can be either a GraphQL string or an AST object from the other GraphQL builtin functions.",
@@ -7527,6 +7589,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "\u003e",
@@ -7666,6 +7729,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "\u003e=",
@@ -7779,6 +7843,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Deserializes the hex-encoded input string.",
@@ -7892,6 +7957,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input string using hex-encoding.",
@@ -8028,6 +8094,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a HTTP response to the given HTTP request.",
@@ -8169,6 +8236,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the index of a substring contained inside a string.",
@@ -8258,6 +8326,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a list of all the indexes of a substring contained inside a string.",
@@ -8349,6 +8418,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "in",
@@ -8441,6 +8511,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "in",
@@ -8527,6 +8598,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "introduced": "v0.34.0",
@@ -8545,6 +8617,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "introduced": "v1.2.0",
@@ -8676,6 +8749,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the intersection of the given input sets.",
@@ -8812,6 +8886,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Decodes a JSON Web Token and outputs it as an object.",
@@ -8953,6 +9028,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies a JWT signature under parameterized constraints and decodes the claims if it is valid.\nSupports the following algorithms: HS256, HS384, HS512, RS256, RS384, RS512, ES256, ES384, ES512, PS256, PS384 and PS512.",
@@ -9099,6 +9175,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Encodes and optionally signs a JSON Web Token. Inputs are taken as objects, not encoded strings (see `io.jwt.encode_sign_raw`).",
@@ -9245,6 +9322,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Encodes and optionally signs a JSON Web Token.",
@@ -9253,6 +9331,32 @@
       "description": "signed JWT",
       "name": "output",
       "type": "string"
+    },
+    "wasm": false
+  },
+  "io.jwt.verify_eddsa": {
+    "args": [
+      {
+        "description": "JWT token whose signature is to be verified",
+        "name": "jwt",
+        "type": "string"
+      },
+      {
+        "description": "PEM encoded certificate, PEM encoded public key, or the JWK key (set) used to verify the signature",
+        "name": "certificate",
+        "type": "string"
+      }
+    ],
+    "available": [
+      "v1.5.0",
+      "edge"
+    ],
+    "description": "Verifies if a edDSA JWT signature is valid.",
+    "introduced": "v1.5.0",
+    "result": {
+      "description": "`true` if the signature is valid, `false` otherwise",
+      "name": "result",
+      "type": "boolean"
     },
     "wasm": false
   },
@@ -9386,6 +9490,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a ES256 JWT signature is valid.",
@@ -9518,6 +9623,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a ES384 JWT signature is valid.",
@@ -9650,6 +9756,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a ES512 JWT signature is valid.",
@@ -9791,6 +9898,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a HS256 (secret) JWT signature is valid.",
@@ -9923,6 +10031,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a HS384 (secret) JWT signature is valid.",
@@ -10055,6 +10164,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a HS512 (secret) JWT signature is valid.",
@@ -10196,6 +10306,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a PS256 JWT signature is valid.",
@@ -10328,6 +10439,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a PS384 JWT signature is valid.",
@@ -10460,6 +10572,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a PS512 JWT signature is valid.",
@@ -10601,6 +10714,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a RS256 JWT signature is valid.",
@@ -10733,6 +10847,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a RS384 JWT signature is valid.",
@@ -10865,6 +10980,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies if a RS512 JWT signature is valid.",
@@ -11001,6 +11117,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is an array.",
@@ -11137,6 +11254,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a boolean.",
@@ -11273,6 +11391,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is null.",
@@ -11409,6 +11528,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a number.",
@@ -11545,6 +11665,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns true if the input value is an object",
@@ -11681,6 +11802,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a set.",
@@ -11817,6 +11939,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `true` if the input value is a string.",
@@ -11958,6 +12081,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Filters the object. For example: `json.filter({\"a\": {\"b\": \"x\", \"c\": \"y\"}}, [\"a/b\"])` will result in `{\"a\": {\"b\": \"x\"}}`). Paths are not filtered in-order and are deduplicated before being evaluated.",
@@ -12072,6 +12196,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies the input string is a valid JSON document.",
@@ -12208,6 +12333,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input term to JSON.",
@@ -12250,6 +12376,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input term JSON, with additional formatting options via the `opts` parameter. `opts` accepts keys `pretty` (enable multi-line/formatted JSON), `prefix` (string to prefix lines with, default empty string) and `indent` (string to indent with, default `\\t`).",
@@ -12311,6 +12438,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks that the document matches the JSON schema.",
@@ -12426,6 +12554,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Patches an object according to RFC6902. For example: `json.patch({\"a\": {\"foo\": 1}}, [{\"op\": \"add\", \"path\": \"/a/bar\", \"value\": 2}])` results in `{\"a\": {\"foo\": 1, \"bar\": 2}`. The patches are applied atomically: if any of them fails, the result will be undefined. Additionally works on sets, where a value contained in the set is considered to be its path.",
@@ -12563,6 +12692,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Removes paths from an object. For example: `json.remove({\"a\": {\"b\": \"x\", \"c\": \"y\"}}, [\"a/b\"])` will result in `{\"a\": {\"c\": \"y\"}}`. Paths are not removed in-order and are deduplicated before being evaluated.",
@@ -12699,6 +12829,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Deserializes the input string.",
@@ -12755,6 +12886,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks that the input is a valid JSON schema object. The schema can be either a JSON string or an JSON object.",
@@ -12891,6 +13023,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the input string but with all characters in lower-case.",
@@ -13030,6 +13163,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "\u003c",
@@ -13169,6 +13303,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "\u003c=",
@@ -13305,6 +13440,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the maximum value in a collection.",
@@ -13441,6 +13577,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the minimum value in a collection.",
@@ -13580,6 +13717,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Minus subtracts the second number from the first number or computes the difference between two sets.",
@@ -13720,6 +13858,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Multiplies two numbers.",
@@ -13860,6 +13999,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "infix": "!=",
@@ -14001,6 +14141,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks if a CIDR or IP is contained within another CIDR. `output` is `true` if `cidr_or_ip` (e.g. `127.0.0.64/26` or `127.0.0.1`) is contained within `cidr` (e.g. `127.0.0.1/24`) and `false` otherwise. Supports both IPv4 and IPv6 notations.",
@@ -14137,6 +14278,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks if collections of cidrs or ips are contained within another collection of cidrs and returns matches. This function is similar to `net.cidr_contains` except it allows callers to pass collections of CIDRs or IPs as arguments and returns the matches (as opposed to a boolean result indicating a match between two CIDRs/IPs).",
@@ -14273,6 +14415,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Expands CIDR to set of hosts  (e.g., `net.cidr_expand(\"192.168.0.0/30\")` generates 4 hosts: `{\"192.168.0.0\", \"192.168.0.1\", \"192.168.0.2\", \"192.168.0.3\"}`).",
@@ -14414,6 +14557,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks if a CIDR intersects with another CIDR (e.g. `192.168.0.0/16` overlaps with `192.168.1.0/24`). Supports both IPv4 and IPv6 notations.",
@@ -14483,6 +14627,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Parses an IPv4/IPv6 CIDR and returns a boolean indicating if the provided CIDR is valid.",
@@ -14598,6 +14743,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Merges IP addresses and subnets into the smallest possible list of CIDRs (e.g., `net.cidr_merge([\"192.0.128.0/24\", \"192.0.129.0/24\"])` generates `{\"192.0.128.0/23\"}`.This function merges adjacent subnets where possible, those contained within others and also removes any duplicates.\nSupports both IPv4 and IPv6 notations. IPv6 inputs need a prefix length (e.g. \"/128\").",
@@ -14735,6 +14881,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -14820,6 +14967,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the set of IP addresses (both v4 and v6) that the passed-in `name` resolves to using the standard name resolution mechanisms available.",
@@ -14944,6 +15092,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns an array of numbers in the given (inclusive) range. If `a==b`, then `range == [a]`; if `a \u003e b`, then `range` is in descending order.",
@@ -15001,6 +15150,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns an array of numbers in the given (inclusive) range incremented by a positive step.\n\tIf \"a==b\", then \"range == [a]\"; if \"a \u003e b\", then \"range\" is in descending order.\n\tIf the provided \"step\" is less then 1, an error will be thrown.\n\tIf \"b\" is not in the range of the provided \"step\", \"b\" won't be included in the result.\n\t",
@@ -15140,6 +15290,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Filters the object by keeping only specified keys. For example: `object.filter({\"a\": {\"b\": \"x\", \"c\": \"y\"}, \"d\": \"z\"}, [\"a\"])` will result in `{\"a\": {\"b\": \"x\", \"c\": \"y\"}}`).",
@@ -15286,6 +15437,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns value of an object's key if present, otherwise a default. If the supplied `key` is an `array`, then `object.get` will search through a nested object or array using each key in turn. For example: `object.get({\"a\": [{ \"b\": true }]}, [\"a\", 0, \"b\"], false)` results in `true`.",
@@ -15351,6 +15503,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a set of an object's keys. For example: `object.keys({\"a\": 1, \"b\": true, \"c\": \"d\")` results in `{\"a\", \"b\", \"c\"}`.",
@@ -15490,6 +15643,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Removes specified keys from an object.",
@@ -15571,6 +15725,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Determines if an object `sub` is a subset of another object `super`.Object `sub` is a subset of object `super` if and only if every key in `sub` is also in `super`, **and** for all keys which `sub` and `super` share, they have the same value. This function works with objects, sets, arrays and a set of array and set.If both arguments are objects, then the operation is recursive, e.g. `{\"c\": {\"x\": {10, 15, 20}}` is a subset of `{\"a\": \"b\", \"c\": {\"x\": {10, 15, 20, 25}, \"y\": \"z\"}`. If both arguments are sets, then this function checks if every element of `sub` is a member of `super`, but does not attempt to recurse. If both arguments are arrays, then this function checks if `sub` appears contiguously in order within `super`, and also does not attempt to recurse. If `super` is array and `sub` is set, then this function checks if `super` contains every element of `sub` with no consideration of ordering, and also does not attempt to recurse.",
@@ -15710,6 +15865,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Creates a new object of the asymmetric union of two objects. For example: `object.union({\"a\": 1, \"b\": 2, \"c\": {\"d\": 3}}, {\"a\": 7, \"c\": {\"d\": 4, \"e\": 5}})` will result in `{\"a\": 7, \"b\": 2, \"c\": {\"d\": 4, \"e\": 5}}`.",
@@ -15794,6 +15950,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Creates a new object that is the asymmetric union of all objects merged from left to right. For example: `object.union_n([{\"a\": 1}, {\"b\": 2}, {\"a\": 3}])` will result in `{\"b\": 2, \"a\": 3}`.",
@@ -15924,6 +16081,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns an object that describes the runtime environment where OPA is deployed.",
@@ -16063,6 +16221,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the union of two sets.",
@@ -16203,6 +16362,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Plus adds two numbers together.",
@@ -16288,6 +16448,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "introduced": "v0.34.0",
@@ -16419,6 +16580,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Multiplies elements of an array or set of numbers",
@@ -16494,6 +16656,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Signs an HTTP request object for Amazon Web Services. Currently implements [AWS Signature Version 4 request signing](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) by the `Authorization` header method.",
@@ -16594,6 +16757,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a random integer between `0` and `n` (`n` exclusive). If `n` is `0`, then `y` is always `0`. For any given argument pair (`str`, `n`), the output will be consistent throughout a query evaluation.",
@@ -16731,6 +16895,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -16875,6 +17040,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns all successive matches of the expression.",
@@ -17021,6 +17187,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the specified number of matches when matching the input against the pattern.",
@@ -17162,6 +17329,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks if the intersection of two glob-style regular expressions matches a non-empty set of non-empty strings.\nThe set of regex symbols is limited for this builtin: only `.`, `*`, `+`, `[`, `-`, `]` and `\\` are treated as special symbols.",
@@ -17280,6 +17448,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Checks if a string is a valid regular expression: the detailed syntax for patterns is defined by https://github.com/google/re2/wiki/Syntax.",
@@ -17403,6 +17572,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Matches a string against a regular expression.",
@@ -17483,6 +17653,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Find and replaces the text using the regular expression pattern.",
@@ -17624,6 +17795,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Splits the input string by the occurrences of the given pattern.",
@@ -17775,6 +17947,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Matches a string against a pattern, where there pattern may be glob-like",
@@ -17847,6 +18020,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the chain of metadata for the active rule.\nOrdered starting at the active rule, going outward to the most distant node in its package ancestry.\nA chain entry is a JSON document with two members: \"path\", an array representing the path of the node; and \"annotations\", a JSON document containing the annotations declared for the node.\nThe first entry in the chain always points to the active rule, even if it has no declared annotations (in which case the \"annotations\" member is not present).",
@@ -17919,6 +18093,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns annotations declared for the active rule and using the _rule_ scope.",
@@ -18060,6 +18235,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Parses the input Rego string and returns an object representation of the AST.",
@@ -18199,6 +18375,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the remainder for of `x` divided by `y`, for `y != 0`.",
@@ -18346,6 +18523,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Replace replaces all instances of a sub-string.",
@@ -18482,6 +18660,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Rounds the number to the nearest integer.",
@@ -18606,6 +18785,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Compares valid SemVer formatted version strings.",
@@ -18725,6 +18905,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Validates that the input is a valid SemVer string.",
@@ -18862,6 +19043,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "deprecated": true,
@@ -18996,6 +19178,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a sorted array.",
@@ -19137,6 +19320,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Split returns an array containing elements of the input string split on a delimiter.",
@@ -19278,6 +19462,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the given string, formatted.",
@@ -19419,6 +19604,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns true if the search string begins with the base string.",
@@ -19495,6 +19681,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns true if any of the search strings begins with any of the base strings.",
@@ -19571,6 +19758,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns true if any of the search strings ends with any of the base strings.",
@@ -19609,6 +19797,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the number of non-overlapping instances of a substring in a string.",
@@ -19657,6 +19846,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Renders a templated string with given template variables injected. For a given templated string and key/value mapping, values will be injected into the template where they are referenced by key.\n\tFor examples of templating syntax, see https://pkg.go.dev/text/template",
@@ -19798,6 +19988,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Replaces a string from a list of old, new string pairs.\nReplacements are performed in the order they appear in the target string, without overlapping matches.\nThe old string comparisons are done in argument order.",
@@ -19884,6 +20075,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Reverses a given string.",
@@ -20030,6 +20222,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the  portion of a string for a given `offset` and a `length`.  If `length \u003c 0`, `output` is the remainder of the string.",
@@ -20166,6 +20359,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Sums elements of an array or set of numbers.",
@@ -20311,6 +20505,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the nanoseconds since epoch after adding years, months and days to nanoseconds. Month \u0026 day values outside their usual ranges after the operation and will be normalized - for example, October 32 would become November 1. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -20447,6 +20642,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the `[hour, minute, second]` of the day for the nanoseconds since epoch.",
@@ -20583,6 +20779,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the `[year, month, day]` for the nanoseconds since epoch.",
@@ -20692,6 +20889,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the difference between two unix timestamps in nanoseconds (with optional timezone strings).",
@@ -20752,6 +20950,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the formatted timestamp for the nanoseconds since epoch.",
@@ -20882,6 +21081,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the current time since epoch in nanoseconds.",
@@ -21018,6 +21218,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the duration in nanoseconds represented by a string.",
@@ -21159,6 +21360,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the time in nanoseconds parsed from the string in the given format. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -21295,6 +21497,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the time in nanoseconds parsed from the string in RFC3339 format. `undefined` if the result would be outside the valid time range that can fit within an `int64`.",
@@ -21431,6 +21634,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the day of the week (Monday, Tuesday, ...) for the nanoseconds since epoch.",
@@ -21567,6 +21771,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Converts a string, bool, or number value to a number: Strings are converted to numbers using `strconv.Atoi`, Boolean `false` is converted to 0 and `true` is converted to 1.",
@@ -21703,6 +21908,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Emits `note` as a `Note` event in the query explanation. Query explanations show the exact expressions evaluated by OPA during policy execution. For example, `trace(\"Hello There!\")` includes `Note \"Hello There!\"` in the query explanation. To include variables in the message, use `sprintf`. For example, `person := \"Bob\"; trace(sprintf(\"Hello There! %v\", [person]))` will emit `Note \"Hello There! Bob\"` inside of the explanation.",
@@ -21844,6 +22050,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `value` with all leading or trailing instances of the `cutset` characters removed.",
@@ -21985,6 +22192,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `value` with all leading instances of the `cutset` characters removed.",
@@ -22126,6 +22334,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `value` without the prefix. If `value` doesn't start with `prefix`, it is returned unchanged.",
@@ -22267,6 +22476,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `value` with all trailing instances of the `cutset` characters removed.",
@@ -22403,6 +22613,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Return the given string with all leading and trailing white space removed.",
@@ -22544,6 +22755,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns `value` without the suffix. If `value` doesn't end with `suffix`, it is returned unchanged.",
@@ -22680,6 +22892,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the type of its input value.",
@@ -22816,6 +23029,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the union of the given input sets.",
@@ -22893,6 +23107,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Converts strings like \"10G\", \"5K\", \"4M\", \"1500m\", and the like into a number.\nThis number can be a non-integer, such as 1.5, 0.22, etc. Scientific notation is supported,\nallowing values such as \"1e-3K\" (1) or \"2.5e6M\" (2.5 million M).\n\nSupports standard metric decimal and binary SI units (e.g., K, Ki, M, Mi, G, Gi, etc.) where\nm, K, M, G, T, P, and E are treated as decimal units and Ki, Mi, Gi, Ti, Pi, and Ei are treated as\nbinary units.\n\nNote that 'm' and 'M' are case-sensitive to allow distinguishing between \"milli\" and \"mega\" units\nrespectively. Other units are case-insensitive.",
@@ -23029,6 +23244,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Converts strings like \"10GB\", \"5K\", \"4mb\", or \"1e6KB\" into an integer number of bytes.\n\nSupports standard byte units (e.g., KB, KiB, etc.) where KB, MB, GB, and TB are treated as decimal\nunits, and KiB, MiB, GiB, and TiB are treated as binary units. Scientific notation is supported,\nenabling values like \"1.5e3MB\" (1500MB) or \"2e6GiB\" (2 million GiB).\n\nThe bytes symbol (b/B) in the unit is optional; omitting it will yield the same result (e.g., \"Mi\"\nand \"MiB\" are equivalent).",
@@ -23165,6 +23381,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns the input string but with all characters in upper-case.",
@@ -23301,6 +23518,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Decodes a URL-encoded input string.",
@@ -23416,6 +23634,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Decodes the given URL query string into an object.",
@@ -23552,6 +23771,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Encodes the input string into a URL-encoded string.",
@@ -23688,6 +23908,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Encodes the given object into a URL encoded query string.",
@@ -23734,6 +23955,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Parses the string value as an UUID and returns an object with the well-defined fields of the UUID if valid.",
@@ -23861,6 +24083,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Returns a new UUIDv4.",
@@ -23997,6 +24220,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Generates `[path, value]` tuples for all nested documents of `x` (recursively).  Queries can use `walk` to traverse documents nested under `x`.",
@@ -24112,6 +24336,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Verifies the input string is a valid YAML document.",
@@ -24248,6 +24473,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Serializes the input term to YAML.",
@@ -24384,6 +24610,7 @@
       "v1.4.0",
       "v1.4.1",
       "v1.4.2",
+      "v1.5.0",
       "edge"
     ],
     "description": "Deserializes the input string.",

--- a/capabilities.json
+++ b/capabilities.json
@@ -1815,6 +1815,23 @@
       "nondeterministic": true
     },
     {
+      "name": "io.jwt.verify_eddsa",
+      "decl": {
+        "args": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "string"
+          }
+        ],
+        "result": {
+          "type": "boolean"
+        },
+        "type": "function"
+      }
+    },
+    {
       "name": "io.jwt.verify_es256",
       "decl": {
         "args": [

--- a/capabilities/v1.5.0.json
+++ b/capabilities/v1.5.0.json
@@ -1,0 +1,4866 @@
+{
+    "builtins": [
+      {
+        "name": "abs",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "all",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "and",
+        "decl": {
+          "args": [
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            },
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        },
+        "infix": "\u0026"
+      },
+      {
+        "name": "any",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "array.concat",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            },
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "array.reverse",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "array.slice",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "assign",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": ":="
+      },
+      {
+        "name": "base64.decode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "base64.encode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "base64.is_valid",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "base64url.decode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "base64url.encode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "base64url.encode_no_pad",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "bits.and",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "bits.lsh",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "bits.negate",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "bits.or",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "bits.rsh",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "bits.xor",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "cast_array",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "cast_boolean",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "cast_null",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "null"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "cast_object",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "cast_set",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "cast_string",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "ceil",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "concat",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "string"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "contains",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "count",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.hmac.equal",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.hmac.md5",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.hmac.sha1",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.hmac.sha256",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.hmac.sha512",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.md5",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.parse_private_keys",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.sha1",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.sha256",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.x509.parse_and_verify_certificates",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "boolean"
+              },
+              {
+                "dynamic": {
+                  "dynamic": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.x509.parse_and_verify_certificates_with_options",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "boolean"
+              },
+              {
+                "dynamic": {
+                  "dynamic": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.x509.parse_certificate_request",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.x509.parse_certificates",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.x509.parse_keypair",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "crypto.x509.parse_rsa_private_key",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "div",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        },
+        "infix": "/"
+      },
+      {
+        "name": "endswith",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "eq",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "="
+      },
+      {
+        "name": "equal",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "=="
+      },
+      {
+        "name": "floor",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "format_int",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "glob.match",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "of": [
+                {
+                  "type": "null"
+                },
+                {
+                  "dynamic": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "glob.quote_meta",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graph.reachable",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "of": [
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "of": {
+                        "type": "any"
+                      },
+                      "type": "set"
+                    }
+                  ],
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graph.reachable_paths",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "of": [
+                    {
+                      "dynamic": {
+                        "type": "any"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "of": {
+                        "type": "any"
+                      },
+                      "type": "set"
+                    }
+                  ],
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "of": {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graphql.is_valid",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graphql.parse",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graphql.parse_and_verify",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "boolean"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graphql.parse_query",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graphql.parse_schema",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "graphql.schema_is_valid",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "gt",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "\u003e"
+      },
+      {
+        "name": "gte",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "\u003e="
+      },
+      {
+        "name": "hex.decode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "hex.encode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "http.send",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "indexof",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "indexof_n",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "internal.member_2",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "in"
+      },
+      {
+        "name": "internal.member_3",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "in"
+      },
+      {
+        "name": "internal.print",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              },
+              "type": "array"
+            }
+          ],
+          "type": "function"
+        }
+      },
+      {
+        "name": "internal.test_case",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            }
+          ],
+          "type": "function"
+        }
+      },
+      {
+        "name": "intersection",
+        "decl": {
+          "args": [
+            {
+              "of": {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              },
+              "type": "set"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.decode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.decode_verify",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "boolean"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "io.jwt.encode_sign",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "io.jwt.encode_sign_raw",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "io.jwt.verify_es256",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_es384",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_es512",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_hs256",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_hs384",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_hs512",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_ps256",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_ps384",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_ps512",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_rs256",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_rs384",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_rs512",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "io.jwt.verify_eddsa",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_array",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_boolean",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_null",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_number",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_object",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_set",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "is_string",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.filter",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.is_valid",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.marshal",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.marshal_with_options",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "static": [
+                {
+                  "key": "indent",
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "key": "prefix",
+                  "value": {
+                    "type": "string"
+                  }
+                },
+                {
+                  "key": "pretty",
+                  "value": {
+                    "type": "boolean"
+                  }
+                }
+              ],
+              "type": "object"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.match_schema",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "boolean"
+              },
+              {
+                "dynamic": {
+                  "static": [
+                    {
+                      "key": "desc",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "key": "error",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "key": "field",
+                      "value": {
+                        "type": "string"
+                      }
+                    },
+                    {
+                      "key": "type",
+                      "value": {
+                        "type": "string"
+                      }
+                    }
+                  ],
+                  "type": "object"
+                },
+                "type": "array"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.patch",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "dynamic": {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "static": [
+                  {
+                    "key": "op",
+                    "value": {
+                      "type": "string"
+                    }
+                  },
+                  {
+                    "key": "path",
+                    "value": {
+                      "type": "any"
+                    }
+                  }
+                ],
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.remove",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.unmarshal",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "json.verify_schema",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "boolean"
+              },
+              {
+                "of": [
+                  {
+                    "type": "null"
+                  },
+                  {
+                    "type": "string"
+                  }
+                ],
+                "type": "any"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "lower",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "lt",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "\u003c"
+      },
+      {
+        "name": "lte",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "\u003c="
+      },
+      {
+        "name": "max",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "min",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "minus",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "of": [
+              {
+                "type": "number"
+              },
+              {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              }
+            ],
+            "type": "any"
+          },
+          "type": "function"
+        },
+        "infix": "-"
+      },
+      {
+        "name": "mul",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        },
+        "infix": "*"
+      },
+      {
+        "name": "neq",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        },
+        "infix": "!="
+      },
+      {
+        "name": "net.cidr_contains",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.cidr_contains_matches",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "of": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "dynamic": {
+                            "type": "any"
+                          },
+                          "type": "array"
+                        }
+                      ],
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "string"
+                    },
+                    "value": {
+                      "of": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "dynamic": {
+                            "type": "any"
+                          },
+                          "type": "array"
+                        }
+                      ],
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "of": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "dynamic": {
+                          "type": "any"
+                        },
+                        "type": "array"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "of": {
+              "static": [
+                {
+                  "type": "any"
+                },
+                {
+                  "type": "any"
+                }
+              ],
+              "type": "array"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.cidr_expand",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "string"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.cidr_intersects",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.cidr_is_valid",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.cidr_merge",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "of": [
+                      {
+                        "type": "string"
+                      }
+                    ],
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "string"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "string"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.cidr_overlap",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "net.lookup_ip_addr",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "string"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "numbers.range",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "numbers.range_step",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "number"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.filter",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.get",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "any"
+            },
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.keys",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.remove",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.subset",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "dynamic": {
+                    "key": {
+                      "type": "any"
+                    },
+                    "value": {
+                      "type": "any"
+                    }
+                  },
+                  "type": "object"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.union",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "any"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "object.union_n",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "dynamic": {
+                  "key": {
+                    "type": "any"
+                  },
+                  "value": {
+                    "type": "any"
+                  }
+                },
+                "type": "object"
+              },
+              "type": "array"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "opa.runtime",
+        "decl": {
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "or",
+        "decl": {
+          "args": [
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            },
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        },
+        "infix": "|"
+      },
+      {
+        "name": "plus",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        },
+        "infix": "+"
+      },
+      {
+        "name": "print",
+        "decl": {
+          "type": "function",
+          "variadic": {
+            "type": "any"
+          }
+        }
+      },
+      {
+        "name": "product",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "number"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "providers.aws.sign_req",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "any"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "rand.intn",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "re_match",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.find_all_string_submatch_n",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "dynamic": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.find_n",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.globs_match",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.is_valid",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.match",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.replace",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.split",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "regex.template_match",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "rego.metadata.chain",
+        "decl": {
+          "result": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "rego.metadata.rule",
+        "decl": {
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "rego.parse_module",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "rem",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        },
+        "infix": "%"
+      },
+      {
+        "name": "replace",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "round",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "semver.compare",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "semver.is_valid",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "set_diff",
+        "decl": {
+          "args": [
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            },
+            {
+              "of": {
+                "type": "any"
+              },
+              "type": "set"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "sort",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "any"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "any"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "any"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "split",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "sprintf",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "dynamic": {
+                "type": "any"
+              },
+              "type": "array"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "startswith",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "strings.any_prefix_match",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "string"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "string"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "strings.any_suffix_match",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "string"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "string"
+                },
+                {
+                  "dynamic": {
+                    "type": "string"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "string"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "strings.count",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "strings.render_template",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "strings.replace_n",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "strings.reverse",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "substring",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "sum",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "dynamic": {
+                    "type": "number"
+                  },
+                  "type": "array"
+                },
+                {
+                  "of": {
+                    "type": "number"
+                  },
+                  "type": "set"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.add_date",
+        "decl": {
+          "args": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            },
+            {
+              "type": "number"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.clock",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.date",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.diff",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            },
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "number"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.format",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.now_ns",
+        "decl": {
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "time.parse_duration_ns",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.parse_ns",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.parse_rfc3339_ns",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "time.weekday",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "number"
+                },
+                {
+                  "static": [
+                    {
+                      "type": "number"
+                    },
+                    {
+                      "type": "string"
+                    }
+                  ],
+                  "type": "array"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "to_number",
+        "decl": {
+          "args": [
+            {
+              "of": [
+                {
+                  "type": "null"
+                },
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ],
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trace",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trim",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trim_left",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trim_prefix",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trim_right",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trim_space",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "trim_suffix",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "type_name",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "union",
+        "decl": {
+          "args": [
+            {
+              "of": {
+                "of": {
+                  "type": "any"
+                },
+                "type": "set"
+              },
+              "type": "set"
+            }
+          ],
+          "result": {
+            "of": {
+              "type": "any"
+            },
+            "type": "set"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "units.parse",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "units.parse_bytes",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "number"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "upper",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "urlquery.decode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "urlquery.decode_object",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "dynamic": {
+                  "type": "string"
+                },
+                "type": "array"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "urlquery.encode",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "urlquery.encode_object",
+        "decl": {
+          "args": [
+            {
+              "dynamic": {
+                "key": {
+                  "type": "string"
+                },
+                "value": {
+                  "of": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "dynamic": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "of": {
+                        "type": "string"
+                      },
+                      "type": "set"
+                    }
+                  ],
+                  "type": "any"
+                }
+              },
+              "type": "object"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "uuid.parse",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "dynamic": {
+              "key": {
+                "type": "string"
+              },
+              "value": {
+                "type": "any"
+              }
+            },
+            "type": "object"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "uuid.rfc4122",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        },
+        "nondeterministic": true
+      },
+      {
+        "name": "walk",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "static": [
+              {
+                "dynamic": {
+                  "type": "any"
+                },
+                "type": "array"
+              },
+              {
+                "type": "any"
+              }
+            ],
+            "type": "array"
+          },
+          "type": "function"
+        },
+        "relation": true
+      },
+      {
+        "name": "yaml.is_valid",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "boolean"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "yaml.marshal",
+        "decl": {
+          "args": [
+            {
+              "type": "any"
+            }
+          ],
+          "result": {
+            "type": "string"
+          },
+          "type": "function"
+        }
+      },
+      {
+        "name": "yaml.unmarshal",
+        "decl": {
+          "args": [
+            {
+              "type": "string"
+            }
+          ],
+          "result": {
+            "type": "any"
+          },
+          "type": "function"
+        }
+      }
+    ],
+    "wasm_abi_versions": [
+      {
+        "version": 1,
+        "minor_version": 1
+      },
+      {
+        "version": 1,
+        "minor_version": 2
+      }
+    ],
+    "features": [
+      "rego_v1"
+    ]
+  }

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -459,7 +459,7 @@ The following algorithms are supported:
 	RS256       "RS256" // RSASSA-PKCS-v1.5 using SHA-256
 	RS384       "RS384" // RSASSA-PKCS-v1.5 using SHA-384
 	RS512       "RS512" // RSASSA-PKCS-v1.5 using SHA-512
-    EDDSA       "EdDSA" // EdDDSA using Ed25519
+	EDDSA       "EdDSA" // EdDDSA using Ed25519
 
 
 {{< info >}}

--- a/docs/content/policy-reference.md
+++ b/docs/content/policy-reference.md
@@ -459,6 +459,7 @@ The following algorithms are supported:
 	RS256       "RS256" // RSASSA-PKCS-v1.5 using SHA-256
 	RS384       "RS384" // RSASSA-PKCS-v1.5 using SHA-384
 	RS512       "RS512" // RSASSA-PKCS-v1.5 using SHA-512
+    EDDSA       "EdDSA" // EdDDSA using Ed25519
 
 
 {{< info >}}
@@ -537,6 +538,33 @@ io.jwt.encode_sign({
 })
 ```
 ```live:jwt/rs256:output
+```
+
+##### EdDSA Key (Ed25519 Signature)
+
+```live:jwt/rs256:query:merge_down
+io.jwt.encode_sign({
+    "alg": "EdDSA"
+}, {
+    "iss": "joe",
+    "exp": 1300819380,
+    "aud": ["bob", "saul"],
+    "http://example.com/is_root": true,
+    "privateParams": {
+        "private_one": "one",
+        "private_two": "two"
+    }
+},
+{
+    "kty": "OKP",
+    "alg": "EdDSA",
+    "crv": "Ed25519",
+    "d": "MC4CAQAwBQYDK2VwBCIEIEFrKpchjkEL8RoDUfE40sCNvFrnaYvODrLa0eUI0V9-",
+    "x": "MCowBQYDK2VwAyEAsD8QauV-Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew",
+    "use": "sig"
+})
+```
+```live:jwt/eddsa:output
 ```
 
 ##### Raw Token Signing
@@ -756,7 +784,7 @@ Examples of valid values for each timestamp field:
  - Second: `"5"` `"05"`
  - AM/PM mark: `"PM"`
 
-For supported constants, formatting of nanoseconds, time zones, and other fields, see the [Go `time/format` module documentation](https://cs.opensource.google/go/go/+/master:src/time/format.go;l=9-113). 
+For supported constants, formatting of nanoseconds, time zones, and other fields, see the [Go `time/format` module documentation](https://cs.opensource.google/go/go/+/master:src/time/format.go;l=9-113).
 
 #### Timestamp Parsing Example
 
@@ -1041,7 +1069,7 @@ example_verify_resource {
 
 ##### Unsigned Payload Request Signing Example
 The [AWS S3 request signing API](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)
-supports unsigned payload signing option. This example below shows s3 request signing with payload signing disabled. 
+supports unsigned payload signing option. This example below shows s3 request signing with payload signing disabled.
 
 ```live:providers/aws/sign_req_unsigned:module
 req := {"method": "get", "url": "https://examplebucket.s3.amazonaws.com/data"}

--- a/internal/jwx/buffer/buffer.go
+++ b/internal/jwx/buffer/buffer.go
@@ -80,7 +80,6 @@ func (b Buffer) Base64Encode() ([]byte, error) {
 
 // Base64Decode decodes the contents of the Buffer using base64.RawURLEncoding
 func (b *Buffer) Base64Decode(v []byte) error {
-	fmt.Printf("v: %s\n", v)
 	enc := base64.RawURLEncoding
 	out := make([]byte, enc.DecodedLen(len(v)))
 	n, err := enc.Decode(out, v)

--- a/internal/jwx/buffer/buffer.go
+++ b/internal/jwx/buffer/buffer.go
@@ -84,7 +84,6 @@ func (b *Buffer) Base64Decode(v []byte) error {
 	out := make([]byte, enc.DecodedLen(len(v)))
 	n, err := enc.Decode(out, v)
 	if err != nil {
-		fmt.Printf("--- HERE ---\n")
 		return fmt.Errorf("failed to decode from base64: %w", err)
 	}
 	out = out[:n]

--- a/internal/jwx/buffer/buffer.go
+++ b/internal/jwx/buffer/buffer.go
@@ -80,10 +80,12 @@ func (b Buffer) Base64Encode() ([]byte, error) {
 
 // Base64Decode decodes the contents of the Buffer using base64.RawURLEncoding
 func (b *Buffer) Base64Decode(v []byte) error {
+	fmt.Printf("v: %s\n", v)
 	enc := base64.RawURLEncoding
 	out := make([]byte, enc.DecodedLen(len(v)))
 	n, err := enc.Decode(out, v)
 	if err != nil {
+		fmt.Printf("--- HERE ---\n")
 		return fmt.Errorf("failed to decode from base64: %w", err)
 	}
 	out = out[:n]

--- a/internal/jwx/jwa/edwards.go
+++ b/internal/jwx/jwa/edwards.go
@@ -1,0 +1,9 @@
+package jwa
+
+// EllipticCurveAlgorithm represents the algorithms used for EC keys
+type EdwardsCurveAlgorithm string
+
+// Supported values for EllipticCurveAlgorithm
+const (
+	Ed25519 EdwardsCurveAlgorithm = "Ed25519"
+)

--- a/internal/jwx/jwa/key_type.go
+++ b/internal/jwx/jwa/key_type.go
@@ -9,7 +9,7 @@ import (
 // KeyType represents the key type ("kty") that are supported
 type KeyType string
 
-var keyTypeAlg = map[string]struct{}{"EC": {}, "oct": {}, "RSA": {}}
+var keyTypeAlg = map[string]struct{}{"EC": {}, "oct": {}, "RSA": {}, "OKP": {}}
 
 // Supported values for KeyType
 const (
@@ -17,6 +17,7 @@ const (
 	InvalidKeyType KeyType = ""    // Invalid KeyType
 	OctetSeq       KeyType = "oct" // Octet sequence (used to represent symmetric keys)
 	RSA            KeyType = "RSA" // RSA
+	OctetKeyPair   KeyType = "OKP" // Octet key pair (used to represent EdDSA key)
 )
 
 // Accept is used when conversion from values given by
@@ -31,6 +32,9 @@ func (keyType *KeyType) Accept(value interface{}) error {
 	default:
 		return fmt.Errorf("invalid type for jwa.KeyType: %T", value)
 	}
+
+	fmt.Printf("tmp: %s \n", tmp.String())
+
 	_, ok := keyTypeAlg[tmp.String()]
 	if !ok {
 		return errors.New("unknown Key Type algorithm")
@@ -58,6 +62,7 @@ func (keyType *KeyType) UnmarshalJSON(data []byte) error {
 	} else {
 		quoted = string(data)
 	}
+	fmt.Printf("quoted: %s\n", quoted)
 	_, ok := keyTypeAlg[quoted]
 	if !ok {
 		return errors.New("unknown signature algorithm")

--- a/internal/jwx/jwa/key_type.go
+++ b/internal/jwx/jwa/key_type.go
@@ -33,8 +33,6 @@ func (keyType *KeyType) Accept(value interface{}) error {
 		return fmt.Errorf("invalid type for jwa.KeyType: %T", value)
 	}
 
-	fmt.Printf("tmp: %s \n", tmp.String())
-
 	_, ok := keyTypeAlg[tmp.String()]
 	if !ok {
 		return errors.New("unknown Key Type algorithm")
@@ -62,7 +60,6 @@ func (keyType *KeyType) UnmarshalJSON(data []byte) error {
 	} else {
 		quoted = string(data)
 	}
-	fmt.Printf("quoted: %s\n", quoted)
 	_, ok := keyTypeAlg[quoted]
 	if !ok {
 		return errors.New("unknown signature algorithm")

--- a/internal/jwx/jwa/signature.go
+++ b/internal/jwx/jwa/signature.go
@@ -9,7 +9,7 @@ import (
 // SignatureAlgorithm represents the various signature algorithms as described in https://tools.ietf.org/html/rfc7518#section-3.1
 type SignatureAlgorithm string
 
-var signatureAlg = map[string]struct{}{"ES256": {}, "ES384": {}, "ES512": {}, "HS256": {}, "HS384": {}, "HS512": {}, "PS256": {}, "PS384": {}, "PS512": {}, "RS256": {}, "RS384": {}, "RS512": {}, "none": {}}
+var signatureAlg = map[string]struct{}{"ES256": {}, "ES384": {}, "ES512": {}, "HS256": {}, "HS384": {}, "HS512": {}, "PS256": {}, "PS384": {}, "PS512": {}, "RS256": {}, "RS384": {}, "RS512": {}, "EdDSA": {}, "none": {}}
 
 // Supported values for SignatureAlgorithm
 const (
@@ -26,6 +26,7 @@ const (
 	RS256       SignatureAlgorithm = "RS256" // RSASSA-PKCS-v1.5 using SHA-256
 	RS384       SignatureAlgorithm = "RS384" // RSASSA-PKCS-v1.5 using SHA-384
 	RS512       SignatureAlgorithm = "RS512" // RSASSA-PKCS-v1.5 using SHA-512
+	EDDSA       SignatureAlgorithm = "EdDSA" // EdDSA (Ed25519) signature
 	NoValue     SignatureAlgorithm = ""      // No value is different from none
 	Unsupported SignatureAlgorithm = "unsupported"
 )
@@ -42,6 +43,7 @@ func (signature *SignatureAlgorithm) Accept(value interface{}) error {
 	default:
 		return fmt.Errorf("invalid type for jwa.SignatureAlgorithm: %T", value)
 	}
+	fmt.Printf("tmp: %s\n", tmp)
 	_, ok := signatureAlg[tmp.String()]
 	if !ok {
 		return errors.New("unknown signature algorithm")

--- a/internal/jwx/jwa/signature.go
+++ b/internal/jwx/jwa/signature.go
@@ -43,7 +43,6 @@ func (signature *SignatureAlgorithm) Accept(value interface{}) error {
 	default:
 		return fmt.Errorf("invalid type for jwa.SignatureAlgorithm: %T", value)
 	}
-	fmt.Printf("tmp: %s\n", tmp)
 	_, ok := signatureAlg[tmp.String()]
 	if !ok {
 		return errors.New("unknown signature algorithm")

--- a/internal/jwx/jwk/eddsa.go
+++ b/internal/jwx/jwk/eddsa.go
@@ -1,0 +1,118 @@
+package jwk
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"errors"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/internal/jwx/jwa"
+)
+
+func newEdDSAPublicKey(key ed25519.PublicKey) (*EDDSAPublicKey, error) {
+
+	var hdr StandardHeaders
+	err := hdr.Set(KeyTypeKey, jwa.EC)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set Key Type: %w", err)
+	}
+
+	return &EDDSAPublicKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+func newEDDSAPrivateKey(key ed25519.PrivateKey) (*EDDSAPrivateKey, error) {
+
+	var hdr StandardHeaders
+	err := hdr.Set(KeyTypeKey, jwa.EC)
+	if err != nil {
+		return nil, fmt.Errorf("failed to set Key Type: %w", err)
+	}
+
+	return &EDDSAPrivateKey{
+		StandardHeaders: &hdr,
+		key:             key,
+	}, nil
+}
+
+// Materialize returns the EC-DSA public key represented by this JWK
+func (k EDDSAPublicKey) Materialize() (interface{}, error) {
+	return k.key, nil
+}
+
+// Materialize returns the EC-DSA private key represented by this JWK
+func (k EDDSAPrivateKey) Materialize() (interface{}, error) {
+	return k.key, nil
+}
+
+// GenerateKey creates a ECDSAPublicKey from JWK format
+func (k *EDDSAPublicKey) GenerateKey(keyJSON *RawKeyJSON) error {
+	fmt.Printf("keyJSON.X: %x\n", keyJSON.X)
+
+	if keyJSON.X == nil || keyJSON.Crv == "" {
+		return errors.New("missing mandatory key parameters X, Crv")
+	}
+
+	switch keyJSON.Crv {
+	// case jwa.EdwardsCurveAlgorithm(jwa.Ed25519):
+	case "ed25519":
+	default:
+		return fmt.Errorf("invalid curve name %s", keyJSON.Crv)
+	}
+
+	// block, _ := pem.Decode(keyJSON.X.Bytes())
+	// if block == nil {
+	// 	return fmt.Errorf("failed to decode PEM block containing public key")
+	// }
+
+	parsedKey, err := x509.ParsePKIXPublicKey(keyJSON.X.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to parse public key: %v", err)
+	}
+
+	publicKey, ok := parsedKey.(ed25519.PublicKey)
+	if !ok {
+		return fmt.Errorf("not an Ed25519 public key")
+	}
+
+	*k = EDDSAPublicKey{
+		StandardHeaders: &keyJSON.StandardHeaders,
+		key:             publicKey,
+	}
+
+	fmt.Printf("OK GenerateKey public\n")
+	return nil
+}
+
+// GenerateKey creates a ECDSAPrivateKey from JWK format
+func (k *EDDSAPrivateKey) GenerateKey(keyJSON *RawKeyJSON) error {
+	fmt.Printf("keyJSON.D: %x\n", keyJSON.D)
+	if keyJSON.D == nil {
+		return errors.New("missing mandatory key parameter D")
+	}
+
+	// block, _ := pem.Decode(keyJSON.D.Bytes())
+	// if block == nil {
+	// 	return fmt.Errorf("failed to decode PEM block containing private key")
+	// }
+
+	parsedKey, err := x509.ParsePKCS8PrivateKey(keyJSON.D.Bytes())
+	if err != nil {
+		return fmt.Errorf("failed to parse private key: %v", err)
+	}
+
+	privateKey, ok := parsedKey.(ed25519.PrivateKey)
+	if !ok {
+		return fmt.Errorf("not an Ed25519 private key")
+	}
+
+	*k = EDDSAPrivateKey{
+		StandardHeaders: &keyJSON.StandardHeaders,
+		key:             privateKey,
+	}
+
+	fmt.Printf("OK GenerateKey private\n")
+	return nil
+}

--- a/internal/jwx/jwk/eddsa.go
+++ b/internal/jwx/jwk/eddsa.go
@@ -37,35 +37,34 @@ func newEDDSAPrivateKey(key ed25519.PrivateKey) (*EDDSAPrivateKey, error) {
 	}, nil
 }
 
-// Materialize returns the EC-DSA public key represented by this JWK
-func (k EDDSAPublicKey) Materialize() (interface{}, error) {
+// Materialize returns the standard EdDSA Public Key representation stored in the internal representation
+func (k *EDDSAPublicKey) Materialize() (interface{}, error) {
+	if k.key == nil {
+		return nil, errors.New("key has no ed25519.PublicKey associated with it")
+	}
 	return k.key, nil
 }
 
-// Materialize returns the EC-DSA private key represented by this JWK
-func (k EDDSAPrivateKey) Materialize() (interface{}, error) {
+// Materialize returns the standard EdDSA Private Key representation stored in the internal representation
+func (k *EDDSAPrivateKey) Materialize() (interface{}, error) {
+	if k.key == nil {
+		return nil, errors.New("key has no ed25519.PrivateKey associated with it")
+	}
 	return k.key, nil
 }
 
 // GenerateKey creates a ECDSAPublicKey from JWK format
 func (k *EDDSAPublicKey) GenerateKey(keyJSON *RawKeyJSON) error {
-	fmt.Printf("keyJSON.X: %x\n", keyJSON.X)
-
 	if keyJSON.X == nil || keyJSON.Crv == "" {
 		return errors.New("missing mandatory key parameters X, Crv")
 	}
 
 	switch keyJSON.Crv {
 	// case jwa.EdwardsCurveAlgorithm(jwa.Ed25519):
-	case "ed25519":
+	case "Ed25519":
 	default:
 		return fmt.Errorf("invalid curve name %s", keyJSON.Crv)
 	}
-
-	// block, _ := pem.Decode(keyJSON.X.Bytes())
-	// if block == nil {
-	// 	return fmt.Errorf("failed to decode PEM block containing public key")
-	// }
 
 	parsedKey, err := x509.ParsePKIXPublicKey(keyJSON.X.Bytes())
 	if err != nil {
@@ -82,21 +81,14 @@ func (k *EDDSAPublicKey) GenerateKey(keyJSON *RawKeyJSON) error {
 		key:             publicKey,
 	}
 
-	fmt.Printf("OK GenerateKey public\n")
 	return nil
 }
 
 // GenerateKey creates a ECDSAPrivateKey from JWK format
 func (k *EDDSAPrivateKey) GenerateKey(keyJSON *RawKeyJSON) error {
-	fmt.Printf("keyJSON.D: %x\n", keyJSON.D)
 	if keyJSON.D == nil {
 		return errors.New("missing mandatory key parameter D")
 	}
-
-	// block, _ := pem.Decode(keyJSON.D.Bytes())
-	// if block == nil {
-	// 	return fmt.Errorf("failed to decode PEM block containing private key")
-	// }
 
 	parsedKey, err := x509.ParsePKCS8PrivateKey(keyJSON.D.Bytes())
 	if err != nil {
@@ -113,6 +105,5 @@ func (k *EDDSAPrivateKey) GenerateKey(keyJSON *RawKeyJSON) error {
 		key:             privateKey,
 	}
 
-	fmt.Printf("OK GenerateKey private\n")
 	return nil
 }

--- a/internal/jwx/jwk/eddsa_test.go
+++ b/internal/jwx/jwk/eddsa_test.go
@@ -1,0 +1,235 @@
+package jwk_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/open-policy-agent/opa/internal/jwx/jwa"
+	"github.com/open-policy-agent/opa/internal/jwx/jwk"
+)
+
+func TestEdDSA(t *testing.T) {
+	verify := func(t *testing.T, key jwk.Key) {
+		t.Helper()
+
+		eddsaKey, err := key.Materialize()
+		if err != nil {
+			t.Fatalf("Materialize() failed: %s", err.Error())
+		}
+
+		newKey, err := jwk.New(eddsaKey)
+		if err != nil {
+			t.Fatalf("jwk.New failed: %s", err.Error())
+		}
+
+		err = key.Walk(func(k string, v interface{}) error {
+			return newKey.Set(k, v)
+		})
+		if err != nil {
+			t.Fatalf("Failed to walk key: %s", err.Error())
+		}
+
+		jsonBuf1, err := json.Marshal(key)
+		if err != nil {
+			t.Fatalf("JSON marshal failed: %s", err.Error())
+		}
+
+		jsonBuf2, err := json.Marshal(newKey)
+		if err != nil {
+			t.Fatalf("JSON marshal failed: %s", err.Error())
+		}
+
+		if !bytes.Equal(jsonBuf1, jsonBuf2) {
+			t.Fatal("JSON marshal buffers do not match")
+		}
+	}
+	t.Run("Public Key", func(t *testing.T) {
+		const jwkSrc = `{
+            "kty": "OKP",
+            "alg": "EdDSA",
+            "crv": "Ed25519",
+            "x": "MCowBQYDK2VwAyEAsD8QauV-Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew",
+            "use": "sig"
+        }`
+
+		var jwkKey jwk.Key
+
+		// It might be a single key
+		rawKeyJSON := &jwk.RawKeyJSON{}
+		err := json.Unmarshal([]byte(jwkSrc), rawKeyJSON)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal JWK: %s", err.Error())
+		}
+		jwkKey, err = rawKeyJSON.GenerateKey()
+		if err != nil {
+			t.Fatalf("Failed to generate key: %v", err)
+		}
+		if _, ok := jwkKey.(*jwk.ECDSAPublicKey); !ok {
+			t.Fatalf("Key type should be of type: %s", fmt.Sprintf("%T", jwkKey))
+		}
+		eddsaKey, err := jwkKey.Materialize()
+		if err != nil {
+			t.Fatalf("Failed to materialize symmetric key: %v", err)
+		}
+		if jwk.GetKeyTypeFromKey(eddsaKey) != jwa.KeyType(jwa.EDDSA) {
+			t.Fatal("Wrong Key Type")
+		}
+
+		verify(t, jwkKey)
+	})
+	t.Run("No Key Type Error", func(t *testing.T) {
+		const jwkSrc = `{
+            "alg": "EdDSA",
+            "crv": "Ed25519",
+            "x": "MCowBQYDK2VwAyEAsD8QauV-Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew",
+            "use": "sig"
+        }`
+
+		// It might be a single key
+		rawKeyJSON := &jwk.RawKeyJSON{}
+		err := json.Unmarshal([]byte(jwkSrc), rawKeyJSON)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal JWK: %s", err.Error())
+		}
+		_, err = rawKeyJSON.GenerateKey()
+		if err == nil {
+			t.Fatal("Key generation should have failed")
+		}
+
+	})
+	// 	t.Run("Single Private Key Error", func(t *testing.T) {
+	// 		const jwkSrc = `{
+	//   "e": "AQAB",
+	//   "kty": "RSA",
+	//   "n": "0vx7agoebGcQSuuPiLJXZptN9nndrQmbXEps2aiAFbWhM78LhWx4cbbfAAtVT86zwu1RK7aPFFxuhDR1L6tSoc_BJECPebWKRXjBZCiFV4n3oknjhMstn64tZ_2W-5JsGY4Hc5n9yBXArwl93lqt7_RN5w6Cf0h4QyQ5v-65YGjQR0_FDW2QvzqY368QQMicAtaSqzs8KJZgnYb9c7d0zgdAZHzu6qMQvRL5hajrn1n91CbOpbISD08qNLyrdkt-bFTWhAI4vMQFh6WeZu0fM4lFd2NcRwr3XPksINHaQ-G_xBniIqbw0Ls1jF44-csFCur-kEgU8awapJzKnqDKgw",
+	//   "d": "X4cTteJY_gn4FYPsXB8rdXix5vwsg1FLN5E3EaG6RJoVH-HLLKD9M7dx5oo7GURknchnrRweUkC7hT5fJLM0WbFAKNLWY2vv7B6NqXSzUvxT0_YSfqijwp3RTzlBaCxWp4doFk5N2o8Gy_nHNKroADIkJ46pRUohsXywbReAdYaMwFs9tv8d_cPVY3i07a3t8MN6TNwm0dSawm9v47UiCl3Sk5ZiG7xojPLu4sbg1U2jx4IBTNBznbJSzFHK66jT8bgkuqsk0GjskDJk19Z4qwjwbsnn4j2WBii3RL-Us2lGVkY8fkFzme1z0HbIkfz0Y6mqnOYtqc0X4jfcKoAC8Q",
+	//   "p": "83i-7IvMGXoMXCskv73TKr8637FiO7Z27zv8oj6pbWUQyLPQBQxtPVnwD20R-60eTDmD2ujnMt5PoqMrm8RfmNhVWDtjjMmCMjOpSXicFHj7XOuVIYQyqVWlWEh6dN36GVZYk93N8Bc9vY41xy8B9RzzOGVQzXvNEvn7O0nVbfs",
+	//   "dp": "G4sPXkc6Ya9y8oJW9_ILj4xuppu0lzi_H7VTkS8xj5SdX3coE0oimYwxIi2emTAue0UOa5dpgFGyBJ4c8tQ2VF402XRugKDTP8akYhFo5tAA77Qe_NmtuYZc3C3m3I24G2GvR5sSDxUyAN2zq8Lfn9EUms6rY3Ob8YeiKkTiBj0",
+	//   "dq": "s9lAH9fggBsoFR8Oac2R_E2gw282rT2kGOAhvIllETE1efrA6huUUvMfBcMpn8lqeW6vzznYY5SSQF7pMdC_agI3nG8Ibp1BUb0JUiraRNqUfLhcQb_d9GF4Dh7e74WbRsobRonujTYN1xCaP6TO61jvWrX-L18txXw494Q_cgk",
+	//   "qi": "GyM_p6JrXySiz1toFgKbWV-JdI3jQ4ypu9rbMWx3rQJBfmt0FoYzgUIZEVFEcOqwemRN81zoDAaa-Bk0KWNGDjJHZDdDmFhW3AN7lI-puxk_mHZGJ11rxyR8O55XLSe3SPmRfKwZI6yU24ZxvQKFYItdldUKGzO6Ia6zTKhAVRU",
+	//   "alg": "RS256",
+	//   "kid": "2011-04-29"
+	// }`
+	// 		// It might be a single key
+	// 		rawKeyJSON := &jwk.RawKeyJSON{}
+	// 		err := json.Unmarshal([]byte(jwkSrc), rawKeyJSON)
+	// 		if err != nil {
+	// 			t.Fatalf("Failed to unmarshal JWK: %s", err.Error())
+	// 		}
+	// 		_, err = rawKeyJSON.GenerateKey()
+	// 		if err == nil {
+	// 			t.Fatalf("Key generation should fail")
+	// 		}
+	// 	})
+
+	t.Run("Single Private Key", func(t *testing.T) {
+		const jwkSrc = `{
+            "kty": "OKP",
+            "alg": "EdDSA",
+            "crv": "Ed25519",
+            "d": "MC4CAQAwBQYDK2VwBCIEIEFrKpchjkEL8RoDUfE40sCNvFrnaYvODrLa0eUI0V9-",
+            "use": "sig"
+        }`
+		var jwkKey jwk.Key
+		rawKeySetJSON := &jwk.RawKeySetJSON{}
+		err := json.Unmarshal([]byte(jwkSrc), rawKeySetJSON)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal JWK Set: %s", err.Error())
+		}
+		if len(rawKeySetJSON.Keys) == 0 {
+			// It might be a single key
+			rawKeyJSON := &jwk.RawKeyJSON{}
+			err := json.Unmarshal([]byte(jwkSrc), rawKeyJSON)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal JWK: %s", err.Error())
+			}
+			jwkKey, err = rawKeyJSON.GenerateKey()
+			if err != nil {
+				t.Fatalf("Failed to generate key: %v", err)
+			}
+			if _, ok := jwkKey.(*jwk.RSAPrivateKey); !ok {
+				t.Fatalf("Key type should be of type: %s", fmt.Sprintf("%T", jwkKey))
+			}
+			eddsaKey, err := jwkKey.Materialize()
+			if err != nil {
+				t.Fatal("Failed to materialize symmetric key")
+			}
+			if jwk.GetKeyTypeFromKey(eddsaKey) != jwa.KeyType(jwa.EDDSA) {
+				t.Fatal("Wrong Key Type")
+			}
+		} else {
+			t.Fatal("Incorrect number of keys")
+		}
+		verify(t, jwkKey)
+	})
+	t.Run("JWK Set of one Private Key", func(t *testing.T) {
+		jwkSrc := `{
+  "keys": [
+    {
+            "kty": "OKP",
+            "alg": "EdDSA",
+            "crv": "Ed25519",
+            "d": "MC4CAQAwBQYDK2VwBCIEIEFrKpchjkEL8RoDUfE40sCNvFrnaYvODrLa0eUI0V9-",
+            "use": "sig"
+        }
+  ]
+}`
+		var jwkKey jwk.Key
+		rawKeySetJSON := &jwk.RawKeySetJSON{}
+		err := json.Unmarshal([]byte(jwkSrc), rawKeySetJSON)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal JWK Set: %s", err.Error())
+		}
+		if len(rawKeySetJSON.Keys) == 0 {
+			t.Fatal("Incorrect number of keys")
+		} else {
+			rawKeyJSON := rawKeySetJSON.Keys[0]
+			jwkKey, err = rawKeyJSON.GenerateKey()
+			if err != nil {
+				t.Fatalf("Failed to generate key: %v", err)
+			}
+			if _, ok := jwkKey.(*jwk.RSAPrivateKey); !ok {
+				t.Fatalf("Key type should be of type: %s", fmt.Sprintf("%T", jwkKey))
+			}
+		}
+		verify(t, jwkKey)
+	})
+}
+
+func TestEdDSAMaterializeErrors(t *testing.T) {
+	t.Run("No Standard Public Key", func(t *testing.T) {
+		eddsaPublicKey := &jwk.EDDSAPublicKey{}
+		_, err := eddsaPublicKey.Materialize()
+		if err == nil {
+			t.Fatal("Materialize key should fail")
+		}
+	})
+	t.Run("No Standard Private Key", func(t *testing.T) {
+		eddsaPublicKey := &jwk.EDDSAPublicKey{}
+		_, err := eddsaPublicKey.Materialize()
+		if err == nil {
+			t.Fatal("Materialize key should fail")
+		}
+	})
+}
+
+func TestEdDSAGenerateErrors(t *testing.T) {
+	t.Run("Raw JWK missing D", func(t *testing.T) {
+		rawKeyJSON := &jwk.RawKeyJSON{}
+		eddsaPublicKey := &jwk.EDDSAPublicKey{}
+		err := eddsaPublicKey.GenerateKey(rawKeyJSON)
+		if err == nil {
+			t.Fatal("Materialize key should fail")
+		}
+	})
+	t.Run("Raw JWK missing X", func(t *testing.T) {
+		rawKeyJSON := &jwk.RawKeyJSON{}
+		eddsaPublicKey := &jwk.EDDSAPrivateKey{}
+		err := eddsaPublicKey.GenerateKey(rawKeyJSON)
+		if err == nil {
+			t.Fatal("Materialize key should fail")
+		}
+	})
+}

--- a/internal/jwx/jwk/eddsa_test.go
+++ b/internal/jwx/jwk/eddsa_test.go
@@ -66,14 +66,14 @@ func TestEdDSA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Failed to generate key: %v", err)
 		}
-		if _, ok := jwkKey.(*jwk.ECDSAPublicKey); !ok {
+		if _, ok := jwkKey.(*jwk.EDDSAPublicKey); !ok {
 			t.Fatalf("Key type should be of type: %s", fmt.Sprintf("%T", jwkKey))
 		}
 		eddsaKey, err := jwkKey.Materialize()
 		if err != nil {
 			t.Fatalf("Failed to materialize symmetric key: %v", err)
 		}
-		if jwk.GetKeyTypeFromKey(eddsaKey) != jwa.KeyType(jwa.EDDSA) {
+		if jwk.GetKeyTypeFromKey(eddsaKey) != jwa.OctetKeyPair {
 			t.Fatal("Wrong Key Type")
 		}
 
@@ -149,14 +149,14 @@ func TestEdDSA(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to generate key: %v", err)
 			}
-			if _, ok := jwkKey.(*jwk.RSAPrivateKey); !ok {
+			if _, ok := jwkKey.(*jwk.EDDSAPrivateKey); !ok {
 				t.Fatalf("Key type should be of type: %s", fmt.Sprintf("%T", jwkKey))
 			}
 			eddsaKey, err := jwkKey.Materialize()
 			if err != nil {
 				t.Fatal("Failed to materialize symmetric key")
 			}
-			if jwk.GetKeyTypeFromKey(eddsaKey) != jwa.KeyType(jwa.EDDSA) {
+			if jwk.GetKeyTypeFromKey(eddsaKey) != jwa.OctetKeyPair {
 				t.Fatal("Wrong Key Type")
 			}
 		} else {
@@ -190,7 +190,7 @@ func TestEdDSA(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to generate key: %v", err)
 			}
-			if _, ok := jwkKey.(*jwk.RSAPrivateKey); !ok {
+			if _, ok := jwkKey.(*jwk.EDDSAPrivateKey); !ok {
 				t.Fatalf("Key type should be of type: %s", fmt.Sprintf("%T", jwkKey))
 			}
 		}

--- a/internal/jwx/jwk/interface.go
+++ b/internal/jwx/jwk/interface.go
@@ -2,6 +2,7 @@ package jwk
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 
 	"github.com/open-policy-agent/opa/internal/jwx/jwa"
@@ -68,4 +69,16 @@ type ECDSAPublicKey struct {
 type ECDSAPrivateKey struct {
 	*StandardHeaders
 	key *ecdsa.PrivateKey
+}
+
+// EDDSAPublicKey is a type of JWK generated from ECDSA public keys
+type EDDSAPublicKey struct {
+	*StandardHeaders
+	key ed25519.PublicKey
+}
+
+// EDCDSAPrivateKey is a type of JWK generated from ECDH-ES private keys
+type EDDSAPrivateKey struct {
+	*StandardHeaders
+	key ed25519.PrivateKey
 }

--- a/internal/jwx/jwk/jwk.go
+++ b/internal/jwx/jwk/jwk.go
@@ -91,7 +91,7 @@ func parse(jwkSrc string) (*Set, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to unmarshal JWK Set: %w", err)
 	}
-	fmt.Printf("rawKeySetJSON: %v\n", rawKeySetJSON)
+
 	if len(rawKeySetJSON.Keys) == 0 {
 
 		// It might be a single key

--- a/internal/jwx/jws/sign/eddsa.go
+++ b/internal/jwx/jws/sign/eddsa.go
@@ -1,0 +1,62 @@
+package sign
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"errors"
+	"fmt"
+
+	"github.com/open-policy-agent/opa/internal/jwx/jwa"
+)
+
+var eddsaSignFuncs = map[jwa.SignatureAlgorithm]eddsaSignFunc{}
+
+func init() {
+	algs := map[jwa.SignatureAlgorithm]crypto.Hash{
+		jwa.EDDSA: crypto.SHA256,
+	}
+
+	for alg, h := range algs {
+		eddsaSignFuncs[alg] = makeEDDSASignFunc(h)
+	}
+}
+
+func makeEDDSASignFunc(hash crypto.Hash) eddsaSignFunc {
+	return eddsaSignFunc(func(payload []byte, key ed25519.PrivateKey) ([]byte, error) {
+
+		s := ed25519.Sign(key, payload)
+
+		return s, nil
+	})
+}
+
+func newEDDSA(alg jwa.SignatureAlgorithm) (*EDDSASigner, error) {
+	fmt.Printf("alg: %s\n", alg)
+	signfn, ok := eddsaSignFuncs[alg]
+	if !ok {
+		return nil, fmt.Errorf("unsupported algorithm while trying to create EDDSA signer: %s", alg)
+	}
+
+	return &EDDSASigner{
+		alg:  alg,
+		sign: signfn,
+	}, nil
+}
+
+// Algorithm returns the signer algorithm
+func (s EDDSASigner) Algorithm() jwa.SignatureAlgorithm {
+	return s.alg
+}
+
+// Sign signs payload with a ECDSA private key
+func (s EDDSASigner) Sign(payload []byte, key interface{}) ([]byte, error) {
+	if key == nil {
+		return nil, errors.New(`missing private key while signing payload`)
+	}
+	ed25519key, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf(`invalid key type %T. ed25519.PrivateKey is required`, key)
+	}
+
+	return s.sign(payload, ed25519key)
+}

--- a/internal/jwx/jws/sign/eddsa.go
+++ b/internal/jwx/jws/sign/eddsa.go
@@ -21,7 +21,7 @@ func init() {
 	}
 }
 
-func makeEDDSASignFunc(hash crypto.Hash) eddsaSignFunc {
+func makeEDDSASignFunc(_ crypto.Hash) eddsaSignFunc {
 	return eddsaSignFunc(func(payload []byte, key ed25519.PrivateKey) ([]byte, error) {
 
 		s := ed25519.Sign(key, payload)
@@ -31,7 +31,6 @@ func makeEDDSASignFunc(hash crypto.Hash) eddsaSignFunc {
 }
 
 func newEDDSA(alg jwa.SignatureAlgorithm) (*EDDSASigner, error) {
-	fmt.Printf("alg: %s\n", alg)
 	signfn, ok := eddsaSignFuncs[alg]
 	if !ok {
 		return nil, fmt.Errorf("unsupported algorithm while trying to create EDDSA signer: %s", alg)

--- a/internal/jwx/jws/sign/eddsa_test.go
+++ b/internal/jwx/jws/sign/eddsa_test.go
@@ -1,0 +1,35 @@
+package sign
+
+import (
+	"testing"
+
+	"github.com/open-policy-agent/opa/internal/jwx/jwa"
+)
+
+func TestEdDSACSign(t *testing.T) {
+	type dummyStruct struct {
+		dummy1 int
+		dummy2 float64
+	}
+	dummy := &dummyStruct{1, 3.4}
+	t.Run("EdDSA Creation Error", func(t *testing.T) {
+		_, err := newEDDSA(jwa.EDDSA)
+		if err == nil {
+			t.Fatal("EdDSA Object creation should fail")
+		}
+	})
+	t.Run("EdDSA Sign Error", func(t *testing.T) {
+		signer, err := newEDDSA(jwa.EDDSA)
+		if err != nil {
+			t.Fatalf("Signer creation failure: %v", jwa.EDDSA)
+		}
+		_, err = signer.Sign([]byte("payload"), dummy)
+		if err == nil {
+			t.Fatal("EdDSA Object creation should fail")
+		}
+		_, err = signer.Sign([]byte("payload"), []byte(""))
+		if err == nil {
+			t.Fatal("EdDSA Object creation should fail")
+		}
+	})
+}

--- a/internal/jwx/jws/sign/eddsa_test.go
+++ b/internal/jwx/jws/sign/eddsa_test.go
@@ -13,7 +13,7 @@ func TestEdDSACSign(t *testing.T) {
 	}
 	dummy := &dummyStruct{1, 3.4}
 	t.Run("EdDSA Creation Error", func(t *testing.T) {
-		_, err := newEDDSA(jwa.EDDSA)
+		_, err := newEDDSA(jwa.HS256)
 		if err == nil {
 			t.Fatal("EdDSA Object creation should fail")
 		}

--- a/internal/jwx/jws/sign/interface.go
+++ b/internal/jwx/jws/sign/interface.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"io"
 
@@ -43,4 +44,12 @@ type hmacSignFunc func([]byte, []byte) ([]byte, error)
 type HMACSigner struct {
 	alg  jwa.SignatureAlgorithm
 	sign hmacSignFunc
+}
+
+type eddsaSignFunc func([]byte, ed25519.PrivateKey) ([]byte, error)
+
+// EDDSASigner uses crypto/ecdsa to sign the payloads.
+type EDDSASigner struct {
+	alg  jwa.SignatureAlgorithm
+	sign eddsaSignFunc
 }

--- a/internal/jwx/jws/sign/sign.go
+++ b/internal/jwx/jws/sign/sign.go
@@ -18,17 +18,19 @@ func New(alg jwa.SignatureAlgorithm) (Signer, error) {
 		return newECDSA(alg)
 	case jwa.HS256, jwa.HS384, jwa.HS512:
 		return newHMAC(alg)
+	case jwa.EDDSA:
+		return newEDDSA(alg)
 	default:
 		return nil, fmt.Errorf(`unsupported signature algorithm %s`, alg)
 	}
 }
 
-// GetSigningKey returns a *rsa.PrivateKey or *ecdsa.PrivateKey typically encoded in PEM blocks of type "RSA PRIVATE KEY"
-// or "EC PRIVATE KEY" for RSA and ECDSA family of algorithms.
+// GetSigningKey returns a *rsa.PrivateKey or *ecdsa.PrivateKey or ed25519.PrivateKey typically encoded in PEM blocks of type "RSA PRIVATE KEY"
+// or "EC PRIVATE KEY" or "ED PRIVATE KEY" for RSA and ECDSA and EdDSA family of algorithms.
 // For HMAC family, it return a []byte value
 func GetSigningKey(key string, alg jwa.SignatureAlgorithm) (interface{}, error) {
 	switch alg {
-	case jwa.RS256, jwa.RS384, jwa.RS512, jwa.PS256, jwa.PS384, jwa.PS512:
+	case jwa.RS256, jwa.RS384, jwa.RS512, jwa.PS256, jwa.PS384, jwa.PS512, jwa.EDDSA:
 		block, _ := pem.Decode([]byte(key))
 		if block == nil {
 			return nil, errors.New("failed to parse PEM block containing the key")

--- a/internal/jwx/jws/sign/sign.go
+++ b/internal/jwx/jws/sign/sign.go
@@ -26,7 +26,7 @@ func New(alg jwa.SignatureAlgorithm) (Signer, error) {
 }
 
 // GetSigningKey returns a *rsa.PrivateKey or *ecdsa.PrivateKey or ed25519.PrivateKey typically encoded in PEM blocks of type "RSA PRIVATE KEY"
-// or "EC PRIVATE KEY" or "ED PRIVATE KEY" for RSA and ECDSA and EdDSA family of algorithms.
+// or "EC PRIVATE KEY" or "ED25519 PRIVATE KEY" for RSA and ECDSA and EdDSA family of algorithms.
 // For HMAC family, it return a []byte value
 func GetSigningKey(key string, alg jwa.SignatureAlgorithm) (interface{}, error) {
 	switch alg {

--- a/v1/ast/builtins.go
+++ b/v1/ast/builtins.go
@@ -190,6 +190,7 @@ var DefaultBuiltins = [...]*Builtin{
 	JWTVerifyHS256,
 	JWTVerifyHS384,
 	JWTVerifyHS512,
+	JWTVerifyEdDSA,
 	JWTDecodeVerify,
 	JWTEncodeSignRaw,
 	JWTEncodeSign,
@@ -2141,6 +2142,19 @@ var JWTVerifyHS512 = &Builtin{
 		types.Args(
 			types.Named("jwt", types.S).Description("JWT token whose signature is to be verified"),
 			types.Named("secret", types.S).Description("plain text secret used to verify the signature"),
+		),
+		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
+	),
+	Categories: tokensCat,
+}
+
+var JWTVerifyEdDSA = &Builtin{
+	Name:        "io.jwt.verify_eddsa",
+	Description: "Verifies if a edDSA JWT signature is valid.",
+	Decl: types.NewFunction(
+		types.Args(
+			types.Named("jwt", types.S).Description("JWT token whose signature is to be verified"),
+			types.Named("certificate", types.S).Description("PEM encoded certificate, PEM encoded public key, or the JWK key (set) used to verify the signature"),
 		),
 		types.Named("result", types.B).Description("`true` if the signature is valid, `false` otherwise"),
 	),

--- a/v1/ast/version_index.json
+++ b/v1/ast/version_index.json
@@ -539,6 +539,13 @@
       "PreRelease": "",
       "Metadata": ""
     },
+    "io.jwt.verify_eddsa": {
+      "Major": 1,
+      "Minor": 5,
+      "Patch": 0,
+      "PreRelease": "",
+      "Metadata": ""
+    },
     "io.jwt.verify_es256": {
       "Major": 0,
       "Minor": 17,

--- a/v1/topdown/tokens.go
+++ b/v1/topdown/tokens.go
@@ -999,7 +999,6 @@ func (header *tokenHeader) valid() bool {
 func commonBuiltinJWTEncodeSign(bctx BuiltinContext, inputHeaders, jwsPayload, jwkSrc string, iter func(*ast.Term) error) error {
 	keys, err := jwk.ParseString(jwkSrc)
 	if err != nil {
-		fmt.Printf("err: %s\n", err)
 		return err
 	}
 	key, err := keys.Keys[0].Materialize()
@@ -1010,17 +1009,13 @@ func commonBuiltinJWTEncodeSign(bctx BuiltinContext, inputHeaders, jwsPayload, j
 		return errors.New("JWK derived key type and keyType parameter do not match")
 	}
 
-	fmt.Printf("encode_sign ok\n")
-
 	standardHeaders := &jws.StandardHeaders{}
 	jwsHeaders := []byte(inputHeaders)
 	err = json.Unmarshal(jwsHeaders, standardHeaders)
 	if err != nil {
 		return err
 	}
-	fmt.Printf("jwsHeaders: %s\n", jwsHeaders)
 	alg := standardHeaders.GetAlgorithm()
-	fmt.Printf("alg: %s\n", alg)
 	if alg == jwa.Unsupported {
 		return errors.New("unknown signature algorithm")
 	}
@@ -1029,21 +1024,17 @@ func commonBuiltinJWTEncodeSign(bctx BuiltinContext, inputHeaders, jwsPayload, j
 		return errors.New("type is JWT but payload is not JSON")
 	}
 
-	fmt.Printf("jwsPayload: %s\n", jwsPayload)
 	// process payload and sign
 	var jwsCompact []byte
 	jwsCompact, err = jws.SignLiteral([]byte(jwsPayload), alg, key, jwsHeaders, bctx.Seed)
 	if err != nil {
-		fmt.Printf("err: %s\n", err)
 		return err
 	}
-	fmt.Printf("jwsCompact: %s\n", jwsCompact)
 
 	return iter(ast.StringTerm(string(jwsCompact)))
 }
 
 func builtinJWTEncodeSign(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
-	fmt.Printf("builtinJWTEncodeSign\n")
 	inputHeadersAsJSON, err := ast.JSON(operands[0].Value)
 	if err != nil {
 		return fmt.Errorf("failed to prepare JWT headers for marshalling: %v", err)

--- a/v1/topdown/tokens.go
+++ b/v1/topdown/tokens.go
@@ -7,6 +7,7 @@ package topdown
 import (
 	"crypto"
 	"crypto/ecdsa"
+	"crypto/ed25519"
 	"crypto/hmac"
 	"crypto/rsa"
 	"crypto/sha256"
@@ -304,11 +305,11 @@ func getKeysFromCertOrJWK(certificate string) ([]verificationKey, error) {
 		}
 
 		if block.Type == "PUBLIC KEY" {
+			fmt.Print("PUBLIC KEY\n")
 			key, err := x509.ParsePKIXPublicKey(block.Bytes)
 			if err != nil {
 				return nil, fmt.Errorf("failed to parse a PEM public key: %w", err)
 			}
-
 			return []verificationKey{{key: key}}, nil
 		}
 
@@ -476,6 +477,102 @@ func builtinJWTVerifyHS(bctx BuiltinContext, operands []*ast.Term, hashF func() 
 
 	putTokenInCache(bctx, jwt, astSecret, nil, nil, valid)
 
+	return iter(ast.NewTerm(ast.Boolean(valid)))
+}
+
+func verifyEd25519(publicKey interface{}, msg, sig []byte) bool {
+	pubKey, ok := publicKey.(ed25519.PublicKey)
+
+	if !ok {
+		return false
+	}
+
+	return ed25519.Verify(pubKey, msg, sig)
+}
+
+// Implements EdDSA JWT signature verification
+func builtinJWTVerifyEdDSA(bctx BuiltinContext, operands []*ast.Term, iter func(*ast.Term) error) error {
+	jwtVal := operands[0].Value
+	keyVal := operands[1].Value
+	// Check token cache first
+	if found, _, _, valid := getTokenFromCache(bctx, jwtVal, keyVal); found {
+		return iter(ast.NewTerm(ast.Boolean(valid)))
+	}
+
+	jwtStr, err := builtins.StringOperand(jwtVal, 1)
+	if err != nil {
+		return err
+	}
+	keyStr, err := builtins.StringOperand(keyVal, 2)
+	if err != nil {
+		return err
+	}
+
+	// Decode the JWT
+	token, err := decodeJWT(jwtStr)
+	if err != nil {
+		return err
+	}
+	err = token.decodeHeader()
+	if err != nil {
+		return err
+	}
+	header, err := parseTokenHeader(token)
+	if err != nil {
+		return err
+	}
+	// Ensure alg is EdDSA
+	if header.alg != "EdDSA" {
+		putTokenInCache(bctx, jwtVal, keyVal, nil, nil, false)
+		return iter(ast.NewTerm(ast.Boolean(false)))
+	}
+
+	// Parse key(s) from JWK/JWKS/cert
+	fmt.Printf("keyStr: %s\n", keyStr)
+	keys, err := getKeysFromCertOrJWK(string(keyStr))
+	fmt.Printf("err: %s\n", err)
+	if err != nil {
+		return err
+	}
+	signature, err := token.decodeSignature()
+	if err != nil {
+		return err
+	}
+	fmt.Printf("signature: %s\n", signature)
+	sig := []byte(signature)
+	fmt.Printf("sig: %x\n", sig)
+	msg := []byte(token.header + "." + token.payload)
+	fmt.Printf("msg: %s\n", msg)
+
+	valid := false
+
+	if header.kid != "" {
+		if key := getKeyByKid(header.kid, keys); key != nil {
+			valid = verifyEd25519(key.key, msg, sig)
+			putTokenInCache(bctx, jwtVal, keyVal, nil, nil, valid)
+			return iter(ast.NewTerm(ast.Boolean(valid)))
+		}
+	}
+
+	for _, key := range keys {
+		if key.alg == "" {
+			if verifyEd25519(key.key, msg, sig) {
+				fmt.Printf("VALID !!! \n")
+				valid = true
+				break
+			}
+		} else {
+			if header.alg != key.alg {
+				continue
+			}
+			if verifyEd25519(key.key, msg, sig) {
+				valid = true
+				break
+			}
+		}
+	}
+
+	putTokenInCache(bctx, jwtVal, keyVal, nil, nil, valid)
 	return iter(ast.NewTerm(ast.Boolean(valid)))
 }
 
@@ -725,6 +822,7 @@ var tokenAlgorithms = map[string]tokenAlgorithm{
 	"HS256": {crypto.SHA256, verifyHMAC},
 	"HS384": {crypto.SHA384, verifyHMAC},
 	"HS512": {crypto.SHA512, verifyHMAC},
+	"EdDSA": {crypto.SHA256, verifyEdDSA},
 }
 
 // errSignatureNotVerified is returned when a signature cannot be verified.
@@ -792,6 +890,18 @@ func verifyECDSA(key interface{}, _ crypto.Hash, digest []byte, signature []byte
 	if ecdsa.Verify(publicKeyEcdsa, digest, r, s) {
 		return nil
 	}
+	return errSignatureNotVerified
+}
+
+func verifyEdDSA(key interface{}, _ crypto.Hash, payload []byte, sig []byte) error {
+	pub, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return errors.New("EdDSA: invalid public key type")
+	}
+	if ed25519.Verify(pub, payload, sig) {
+		return nil
+	}
+
 	return errSignatureNotVerified
 }
 
@@ -1147,6 +1257,7 @@ func builtinJWTDecodeVerify(bctx BuiltinContext, operands []*ast.Term, iter func
 			return iter(unverified)
 		}
 	}
+
 	// RFC7159 4.1.4 exp
 	if exp := payload.Get(jwtExpKey); exp != nil {
 		switch v := exp.Value.(type) {
@@ -1334,6 +1445,7 @@ func init() {
 	RegisterBuiltinFunc(ast.JWTVerifyHS256.Name, builtinJWTVerifyHS256)
 	RegisterBuiltinFunc(ast.JWTVerifyHS384.Name, builtinJWTVerifyHS384)
 	RegisterBuiltinFunc(ast.JWTVerifyHS512.Name, builtinJWTVerifyHS512)
+	RegisterBuiltinFunc(ast.JWTVerifyEdDSA.Name, builtinJWTVerifyEdDSA)
 	RegisterBuiltinFunc(ast.JWTDecodeVerify.Name, builtinJWTDecodeVerify)
 	RegisterBuiltinFunc(ast.JWTEncodeSignRaw.Name, builtinJWTEncodeSignRaw)
 	RegisterBuiltinFunc(ast.JWTEncodeSign.Name, builtinJWTEncodeSign)

--- a/v1/topdown/tokens_test.go
+++ b/v1/topdown/tokens_test.go
@@ -1091,6 +1091,13 @@ func TestBuiltinJWTVerify_TokenCache(t *testing.T) {
 			badKey:  `{"kty":"EC","crv":"P-256","x":"z8J91ghFy5o6f2xZ4g8LsLH7u2wEpT2ntj8loahnlsE","y":"7bdeXLH61KrGWRdh7ilnbcGQACxykaPKfmBccTHIOUo"}`,
 			builtin: builtinJWTVerifyES512,
 		},
+		{
+			note:    "EdDSA",
+			jwt:     "eyJhbGciOiJFZERTQSJ9.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sIm5iZiI6MTQ1MTYwNjQwMH0.TuZ-bxA5xqXis3DoCk2b1AxW1C6Xsc2YZ-ro5hCdcbLqB9oNeE31Hr35Y85odmPr5Sgh_qGS-MGdjANvg4fXAQ==",
+			key:     "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAsD8QauV+Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew=\n-----END PUBLIC KEY-----",
+			badKey:  "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEADeOePjSGJMmZtpon/SoAAf70RPMHZnRodYSFGpzDwCA=\n-----END PUBLIC KEY-----",
+			builtin: builtinJWTVerifyEdDSA,
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
<!--

Thanks for submitting a PR to OPA!

Before pressing 'Create pull request' please read the checklist below.

* All code changes should be accompanied with tests. If you are not
modifying any tests, just provide a short explanation of why updates
to tests are not necessary. In addition to helping catch bugs, tests
are extremely helpful in providing _context_ that explains how your
changes can be used.

* All changes to public APIs **must** be accompanied with
docs. Examples of public APIs include built-in functions,
config fields, and of course, exported Go types/functions/constants/etc.

* Commit messages should explain _why_ you made the changes, not what
you changed. Use active voice. Keep the subject line under 50
characters or so.

* All commits must be signed off by the author. If you are not
familiar with signing off, see our contributor guide below.

For more information on contributing to OPA see:

* [Contributing Guide](https://www.openpolicyagent.org/docs/latest/contributing/)
  for high-level contributing guidelines and development setup.
  (See the [Developer Certificate of Origin](https://www.openpolicyagent.org/docs/latest/contrib-code/#developer-certificate-of-origin)
  section for specifics on signing off a commit.)

-->

### Why the changes in this PR are needed?

Support EdDSA (ed25519) JWT signature.

<!--
Include a short description of WHY the changes were made.
-->

### What are the changes in this PR?

Add support for EdDSA (ed25519) keys both in jwks and jwt sign/verify generic processes/functions.

Expose a new io.jwt function to verify eddsa signed jwt token: verify_eddsa

<!--
Include a short description of WHAT changes were made.
-->

### Notes to assist PR review:

<!--
Here you can add information you think will help the reviewer(s).
-->

Small example of a  rego test file showing how to use it:

```
package main_test

header := {"typ": "JWT","alg":"EdDSA"}
payload := {"Scopes":["foo","bar"],"nbf":1451606400}
jwt := "eyJhbGciOiJFZERTQSJ9.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sIm5iZiI6MTQ1MTYwNjQwMH0.TuZ-bxA5xqXis3DoCk2b1AxW1C6Xsc2YZ-ro5hCdcbLqB9oNeE31Hr35Y85odmPr5Sgh_qGS-MGdjANvg4fXAQ=="
key := "-----BEGIN PUBLIC KEY-----\nMCowBQYDK2VwAyEAsD8QauV+Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew=\n-----END PUBLIC KEY-----"
private_key := "-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VwBCIEIEFrKpchjkEL8RoDUfE40sCNvFrnaYvODrLa0eUI0V9+\n-----END PRIVATE KEY-----"

test_eddsa_verify_eddsa if {
    result := io.jwt.verify_eddsa(jwt, key)
    result
}

test_eddsa_decode_verify if {
    [verified, _, claims] := io.jwt.decode_verify(jwt, {"cert": key})
    verified
}

test_eddsa_encode_sign if {
    output := io.jwt.encode_sign(
        header,
        payload,
        {
            "kty": "OKP",
            "alg": "EdDSA",
            "crv": "Ed25519",
            "d": "MC4CAQAwBQYDK2VwBCIEIEFrKpchjkEL8RoDUfE40sCNvFrnaYvODrLa0eUI0V9-",
            "x": "MCowBQYDK2VwAyEAsD8QauV-Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew",
            "use": "sig"
        }
    )

    verified := io.jwt.verify_eddsa(output, key)
    verified
}

test_eddsa_encode_sign_raw if {
    output := io.jwt.encode_sign_raw(
        `{"typ": "JWT", "alg":"EdDSA"}`,
        `{"Scopes":["foo","bar"],"nbf":1451606400}`,
        `{
            "kty": "OKP",
            "alg": "EdDSA",
            "crv": "Ed25519",
            "d": "MC4CAQAwBQYDK2VwBCIEIEFrKpchjkEL8RoDUfE40sCNvFrnaYvODrLa0eUI0V9-",
            "x": "MCowBQYDK2VwAyEAsD8QauV-Cgr7kPoZ3MVDDYzov7d8p8LjKOLXI3ni2ew",
            "use": "sig"
        }`
    )
    verified := io.jwt.verify_eddsa(output, key)
    verified
}
```

Test execution:

```
./_release/1.5.0-dev/opa_linux_amd64 test --verbose eddsa_test.rego 
eddsa_test.rego:
data.main_test.test_eddsa_verify_eddsa: PASS (1.355584ms)

  true

data.main_test.test_eddsa_decode_verify: PASS (1.336114ms)

  true
  {"Scopes": ["foo", "bar"], "nbf": 1451606400}

data.main_test.test_eddsa_encode_sign: PASS (3.285951ms)

  eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCJ9.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sIm5iZiI6MTQ1MTYwNjQwMH0.QTJIKnz17HEZZpLanavuLm4AQlxHWsCYVmvePZzTVahbC5n9_crkXEoOBfWCCAeonI6u_VjnPNasXPp4l9d5Cw
  true

data.main_test.test_eddsa_encode_sign_raw: PASS (505.875µs)

  eyJ0eXAiOiAiSldUIiwgImFsZyI6IkVkRFNBIn0.eyJTY29wZXMiOlsiZm9vIiwiYmFyIl0sIm5iZiI6MTQ1MTYwNjQwMH0.IEpxU2r4j68yfdVecCT9cm-cgOELSkFgZbbV5k6Sm_46p6RyGTTAQW7q-cWT7thsWxelf3xgQXHpBEOEr5hKCg
  true

--------------------------------------------------------------------------------
PASS: 4/4
```

### Further comments:

<!--
Here you can include links to additional resources related to the changes, discuss your solution, other approaches you considered etc.
-->

Things to discuss or that are unclear to me:

* as I am not an expert in crypto, I don't really know if the "new modules" are generic enough to be named "eddsa" or if it is better to stick them to only "ed25519".
* with ed25519 there is no real need for a hash before signing but I don't know how to express it properly. Currently I have declared the new algorithm with crypto.SHA256 (see [tokens.go](https://github.com/aromeyer/opa/pull/1/files#diff-04245270ceadb46b32b5ebcb86d1b3113fb4dbea8c1465c64dd2c27cc55e7c18R818)) even if it is unused/useless.
To be consistent I have also kept this "crypto.SHA256" in [jws/sign/eddsa.go](https://github.com/aromeyer/opa/pull/1/files#diff-a1c040c29f0d7addaffc3d1cbf1b6fb9fe462f6f9a6bd1083dcb13f7fc23220dR16) even if it is also useless.
* I don't know exactly how your markdown documentation is generated, so my updates are probably incomplete/wrong
